### PR TITLE
Graphical tweaks

### DIFF
--- a/Assets/Art/Face.png.meta
+++ b/Assets/Art/Face.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
@@ -60,6 +60,18 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Art/Idle.png.meta
+++ b/Assets/Art/Idle.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/JumpSheet.png.meta
+++ b/Assets/Art/JumpSheet.png.meta
@@ -17,13 +17,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/JumpStrip2.png.meta
+++ b/Assets/Art/JumpStrip2.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
@@ -60,6 +60,18 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Art/RunStrip2.png.meta
+++ b/Assets/Art/RunStrip2.png.meta
@@ -14,13 +14,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/SmokeAnim.png.meta
+++ b/Assets/Art/SmokeAnim.png.meta
@@ -17,13 +17,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/Stunned.png.meta
+++ b/Assets/Art/Stunned.png.meta
@@ -8,13 +8,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/Track.png.meta
+++ b/Assets/Art/Track.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/Wrench.png.meta
+++ b/Assets/Art/Wrench.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
@@ -60,6 +60,18 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Art/attackStrip2.png.meta
+++ b/Assets/Art/attackStrip2.png.meta
@@ -11,13 +11,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/background/Track.png.meta
+++ b/Assets/Art/background/Track.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/background/Track.png.meta
+++ b/Assets/Art/background/Track.png.meta
@@ -34,7 +34,7 @@ TextureImporter:
     filterMode: 1
     aniso: -1
     mipBias: -100
-    wrapU: 2
+    wrapU: 0
     wrapV: 1
     wrapW: 1
   nPOTScale: 0

--- a/Assets/Art/background/landscape_0000_1_trees.png.meta
+++ b/Assets/Art/background/landscape_0000_1_trees.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/background/landscape_0000_1_trees.png.meta
+++ b/Assets/Art/background/landscape_0000_1_trees.png.meta
@@ -34,7 +34,7 @@ TextureImporter:
     filterMode: -1
     aniso: -1
     mipBias: -100
-    wrapU: 2
+    wrapU: 0
     wrapV: 1
     wrapW: 0
   nPOTScale: 0

--- a/Assets/Art/background/landscape_0001_2_trees.png.meta
+++ b/Assets/Art/background/landscape_0001_2_trees.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/background/landscape_0002_3_trees.png.meta
+++ b/Assets/Art/background/landscape_0002_3_trees.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
@@ -60,6 +60,18 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Art/background/landscape_0002_3_trees.png.meta
+++ b/Assets/Art/background/landscape_0002_3_trees.png.meta
@@ -34,7 +34,7 @@ TextureImporter:
     filterMode: -1
     aniso: -1
     mipBias: -100
-    wrapU: 1
+    wrapU: 0
     wrapV: 1
     wrapW: 1
   nPOTScale: 0

--- a/Assets/Art/background/landscape_0003_4_mountain.png.meta
+++ b/Assets/Art/background/landscape_0003_4_mountain.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/background/landscape_0004_5_clouds.png.meta
+++ b/Assets/Art/background/landscape_0004_5_clouds.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/background/landscape_0005_6_background.png.meta
+++ b/Assets/Art/background/landscape_0005_6_background.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
@@ -60,6 +60,18 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Art/longTrack.png.meta
+++ b/Assets/Art/longTrack.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/machineStrip2.png.meta
+++ b/Assets/Art/machineStrip2.png.meta
@@ -11,13 +11,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/passengerCar.png.meta
+++ b/Assets/Art/passengerCar.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/playerIdle.png.meta
+++ b/Assets/Art/playerIdle.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/stunStrip3.png.meta
+++ b/Assets/Art/stunStrip3.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
@@ -60,6 +60,18 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Art/stunStrip9.png.meta
+++ b/Assets/Art/stunStrip9.png.meta
@@ -32,13 +32,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Art/trainEngine2.png.meta
+++ b/Assets/Art/trainEngine2.png.meta
@@ -5,13 +5,13 @@ TextureImporter:
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
-    mipMapMode: 0
-    enableMipMap: 0
+    mipMapMode: 1
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
     borderMipMap: 0
-    mipMapsPreserveCoverage: 0
+    mipMapsPreserveCoverage: 1
     alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3

--- a/Assets/Controls/Controller.inputactions
+++ b/Assets/Controls/Controller.inputactions
@@ -705,6 +705,17 @@
                     "action": "Skip",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4a4fe61f-8d0f-4bf3-a111-82f8b68e6731",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         }

--- a/Assets/Controls/Controller.inputactions
+++ b/Assets/Controls/Controller.inputactions
@@ -614,6 +614,99 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "Menu",
+            "id": "b0850778-2c34-4e70-8791-18dccf10ed9e",
+            "actions": [
+                {
+                    "name": "Skip",
+                    "type": "Button",
+                    "id": "864311f5-7fcc-41f7-a935-0038b2458493",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "Press"
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "1e298719-963f-4de1-843a-2feb78cc8901",
+                    "path": "<Keyboard>/anyKey",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1a0514b0-8179-479f-bf6e-237ceacde6f2",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3ab55df6-25ec-41c9-a1a2-95b6e6bb94dd",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "dbaa06af-bb4d-46a0-a62d-d00438049360",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a3843526-b4db-44b9-935c-12cf9b0a3e06",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "412959ae-99c4-409f-ae3e-cbc580b38d22",
+                    "path": "<Gamepad>/select",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2a8ad971-2801-4af1-8d87-0fe0e8c88c24",
+                    "path": "<Gamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
     "controlSchemes": []

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -59,7 +59,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 2
   m_TargetDisplay: 0
 --- !u!114 &71018729
 MonoBehaviour:

--- a/Assets/Scenes/DynamicallyGeneratedLevel.unity
+++ b/Assets/Scenes/DynamicallyGeneratedLevel.unity
@@ -441,7 +441,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 158, y: -101}
+  m_AnchoredPosition: {x: -163.70001, y: -101}
   m_SizeDelta: {x: 301.3, y: 65.900024}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &331599680
@@ -1081,7 +1081,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -143.3, y: -101}
+  m_AnchoredPosition: {x: -465.00003, y: -101}
   m_SizeDelta: {x: 301.3, y: 65.900024}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &760090910
@@ -1360,7 +1360,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 158, y: -35.100098}
+  m_AnchoredPosition: {x: -163.70001, y: -35.100098}
   m_SizeDelta: {x: 301.3, y: 65.900024}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &917747570
@@ -1763,10 +1763,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1280, y: 720}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -2036,7 +2036,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -143.3, y: -35.100098}
+  m_AnchoredPosition: {x: -465, y: -35.100098}
   m_SizeDelta: {x: 301.3, y: 65.900024}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1835449148

--- a/Assets/Scenes/Intro.unity
+++ b/Assets/Scenes/Intro.unity
@@ -215,6 +215,7 @@ GameObject:
   - component: {fileID: 535145733}
   - component: {fileID: 535145732}
   - component: {fileID: 535145734}
+  - component: {fileID: 535145735}
   m_Layer: 0
   m_Name: Video Player
   m_TagString: Untagged
@@ -283,3 +284,34 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   videoPlayer: {fileID: 535145732}
+--- !u!114 &535145735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 535145731}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: d517d2c527ef35b4981113243cf49bc0,
+    type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents: []
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Menu
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}

--- a/Assets/Scripts/Data Models/Game.cs
+++ b/Assets/Scripts/Data Models/Game.cs
@@ -34,7 +34,8 @@ public class Game : MonoBehaviour
         playerColors.Add(3, new Color(0f, 25f, 255f, 255f));
 
         float xLoc = Constants.DISTANCE_BETWEEN_CARS * (numberOfPlayers + Constants.ADDITONAL_CARS)/2 + 0.5f;
-        engine = Instantiate(enginePrefab, new Vector3(xLoc, 0, 0), Quaternion.identity);
+        engine = Instantiate(enginePrefab, new Vector3(xLoc - 1.7f, 0.4f, 0), Quaternion.identity);
+        engine.transform.localScale = new Vector3(0.8f, 0.8f, 1f);
 
         maxPoints = numberOfPlayers * (int)gameTotalTime * 5;
         train = Instantiate(trainPrefab, new Vector3(0, 0, 0), Quaternion.identity);

--- a/Assets/Scripts/Data Models/Player.cs
+++ b/Assets/Scripts/Data Models/Player.cs
@@ -357,6 +357,13 @@ public class Player : MonoBehaviour
     {
         if (repairing)
         {
+            // Early exit if another player finished repairing the same device first
+            // TODO: Change this so that you can't start repairing a device someone else is working on?
+            if (!targetDevice.isDamaged)
+            {
+                FinishRepair(false);
+            }
+
             time += Time.deltaTime;
 
             float timerProgress = (float)time / 1.5f;

--- a/Assets/Scripts/UI Scripts/VideoScript.cs
+++ b/Assets/Scripts/UI Scripts/VideoScript.cs
@@ -14,6 +14,11 @@ public class VideoScript : MonoBehaviour
         videoPlayer.loopPointReached += EndReached;
     }
 
+    public void OnSkip()
+    {
+        EndReached(videoPlayer);
+    }
+
     void EndReached(UnityEngine.Video.VideoPlayer vp)
     {
         SceneManager.LoadScene("Scenes/Main Menu");

--- a/Assets/Takeoff.cs
+++ b/Assets/Takeoff.cs
@@ -21,6 +21,7 @@ public class Takeoff : MonoBehaviour
         int startVelocity = 1050;
 
         int playersLeft = (int) (totalScore / 50);
+        GameState.numSurvivors = playersLeft;
 
         foreach (GameObject trainCar in GameObject.FindGameObjectsWithTag("Train"))
         {


### PR DESCRIPTION
A bunch of minor tweaks and fixes, mostly graphical

- Enabled mipmap generation on all sprites
- Fixed seams on scrolling backgrounds
- Adjusted HUD so it scales properly
- Moved displays (ability time, repair time) to front layer (no longer behind world sprites)
- Added extra check so player stops repairing a device if another player finished repairing the same device first
- Fixed status display on end screen
- Added ability to skip intro video